### PR TITLE
[ADD]메인페이지 레이아웃

### DIFF
--- a/src/pages/MovieMain/MovieMain.jsx
+++ b/src/pages/MovieMain/MovieMain.jsx
@@ -1,12 +1,84 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import styled from 'styled-components'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { popularMovieApi } from 'utils/MovieApi'
+import { useInView } from 'react-intersection-observer'
+import Carousel from './components/Carousel'
 import MovieCard from 'components/MovieCard'
 
 const MovieMain = () => {
+  const { ref, inView } = useInView()
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery(
+    ['popularMovie'],
+    ({ pageParam = 1 }) => popularMovieApi(pageParam),
+    {
+      select: movieLists => {
+        return movieLists.pages.flatMap(movieList => movieList.data.results)
+      },
+      getNextPageParam: (response, currentpages) => {
+        const lastPage = response.data.total_pages
+        if (currentpages.length < lastPage) {
+          return currentpages.length + 1
+        } else {
+          return undefined
+        }
+      },
+    },
+  )
+
+  useEffect(() => {
+    if (inView) {
+      fetchNextPage()
+    }
+  }, [inView, fetchNextPage])
+
   return (
-    <div>
-      <MovieCard poster={'/AfvIjhDu9p64jKcmohS4hsPG95Q.jpg'} vote={7.9} title={'블랙폰'} />
-    </div>
+    <MainPageContainer>
+      <MainPageHeader>
+        <Carousel />
+      </MainPageHeader>
+      <MainPageSection>
+        <MainPageSectionHeader>요즘 인기있는 영화들</MainPageSectionHeader>
+        <MovieList>
+          {data?.map(movieList => (
+            <MovieCard
+              key={movieList.id}
+              poster={movieList.poster_path}
+              title={movieList.title}
+              vote={movieList.vote}
+            ></MovieCard>
+          ))}
+        </MovieList>
+      </MainPageSection>
+      {hasNextPage ? <ContainerBottom ref={ref}></ContainerBottom> : null}
+    </MainPageContainer>
   )
 }
 
 export default MovieMain
+
+const MainPageContainer = styled.div`
+  width: 100%;
+  padding: 0 50px;
+`
+const MainPageHeader = styled.header``
+const MainPageSection = styled.section``
+const MainPageSectionHeader = styled.h1`
+  border-left: 6px solid ${({ theme }) => theme.hover};
+  padding-left: 10px;
+  ${({ theme }) => theme.headerFont};
+`
+const MovieList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 2fr));
+  grid-auto-flow: row;
+  padding: 30px 0;
+  margin-top: 20px;
+  border-top: 2px solid ${({ theme }) => theme.border};
+  justify-items: center;
+`
+
+const ContainerBottom = styled.div`
+  width: 100%;
+  height: 30px;
+`

--- a/src/pages/MovieMain/components/Carousel.jsx
+++ b/src/pages/MovieMain/components/Carousel.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Carousel = props => {
+  return <CarouselContainer>캐러셀영역</CarouselContainer>
+}
+
+export default Carousel
+
+const CarouselContainer = styled.div`
+  width: 100%;
+  height: 600px;
+  background-color: aliceblue;
+`

--- a/src/styles/Theme.js
+++ b/src/styles/Theme.js
@@ -22,7 +22,7 @@ const theme = {
   `,
 
   headerFont: css`
-    font-size: 24px;
+    font-size: 32px;
     font-weight: 700;
   `,
 

--- a/src/utils/MovieApi.js
+++ b/src/utils/MovieApi.js
@@ -1,7 +1,7 @@
 import { Axios } from 'api'
 
-export const popularMovieApi = async () => {
-  return await Axios.get('/movie/popular')
+export const popularMovieApi = async currentPage => {
+  return await Axios.get('/movie/popular', { params: { page: currentPage } })
 }
 export const getMovieList = async (url, page) => {
   try {


### PR DESCRIPTION
메인페이지레이아웃 및 무한스크롤구현

메인페이지의 레이아웃은 Grid 를 활용하여 구성하였고,

useInfiniteQuery를 활용하여 화면이 가장 하단으로 갔을때 추가데이터를 불러오는 방식으로 

무한스크롤을 구현하였습니다.

화면하단을 인식하기 쉽게하기 위해서 'react-intersection-observer' 라이브러리를 추가하였습니다.