### PR TITLE
[FIX]레이아웃,reactquery수정

### DIFF
--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -24,7 +24,6 @@ const MovieCard = ({ poster, title, vote }) => {
         />
         {!loaded && <StyleMovieImageDiv />}
       </MovieImageDiv>
-
       <MovieContent>
         <MovieVote>
           <MovieIconDiv>
@@ -101,12 +100,12 @@ const MovieRateDiv = styled.div`
 `
 
 const MovieVote = styled.div`
-  font-size: 30px;
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
   display: flex;
   align-items: center;
-  position: absolute;
-  top: 5px;
-  right: 5px;
+  font-size: 30px;
   color: ${({ theme }) => theme.hover};
 `
 


### PR DESCRIPTION
추가렌더링이슈 및 레이아웃수정

### 렌더링이슈
intersection observer 라이브러리 사용에 따른 추가적인 query 호출이 생기기 때문에 intersection observer 대신 해당 element에 
교차되는 순간을 확인하는 로직으로 변경하였습니다. ->렌더링 이슈 해결

### 레이아웃
그리드 아이템 간의 간격을 조정하였고 별점이 포스터 위에서 눈에 잘 띄지 않는 경우가 있어 별점의 위치를 변경하였습니다.